### PR TITLE
Add delay before sharing snapshot

### DIFF
--- a/rds_migration_backup_restore/main.py
+++ b/rds_migration_backup_restore/main.py
@@ -136,6 +136,7 @@ def run():
 
     if shared_snapshot_id == "":
         return
+    time.sleep(10)
     share_snapshot(shared_snapshot_id, dest_account_id)
 
 

--- a/rds_migration_backup_restore/main.py
+++ b/rds_migration_backup_restore/main.py
@@ -127,16 +127,18 @@ def run():
     dest_account_id = argv[3]
 
     snapshot_arn = create_snapshot(db_instance_id)
-
     if snapshot_arn == "":
         return
 
+    time.sleep(10)
+
     shared_snapshot_id = copy_snapshot(
         snapshot_arn, kms_key_id, db_instance_id)
-
     if shared_snapshot_id == "":
         return
+
     time.sleep(10)
+
     share_snapshot(shared_snapshot_id, dest_account_id)
 
 


### PR DESCRIPTION
Add delay before sharing snapshot, to ensure all tags are propagated to the snapshot.